### PR TITLE
Implement dragon booking cancelation - Switch badges

### DIFF
--- a/src/components/DragonItem.js
+++ b/src/components/DragonItem.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { reserveDragon } from '../redux/dragons/dragons';
+import { reserveDragon, cancelDragon } from '../redux/dragons/dragons';
 import styles from './styles/DragonItem.module.css';
 
 const DragonItem = (props) => {
@@ -11,6 +11,10 @@ const DragonItem = (props) => {
 
   const reserveClick = (id) => {
     dispatch(reserveDragon(id));
+  };
+
+  const cancelClick = (id) => {
+    dispatch(cancelDragon(id));
   };
 
   return (
@@ -24,22 +28,29 @@ const DragonItem = (props) => {
           Type:
           {dragon.type}
         </p>
-        <button
-          type="button"
-          id={dragon.id}
-          onClick={(e) => reserveClick(e.target.id)}
-          className={`${styles[dragon.reserved ? 'hide' : '']} ${styles.reserveBtn}`}
-        >
-          Reserve Dragon
-        </button>
-        <button
-          type="button"
-          id={dragon.id}
-          onClick={(e) => reserveClick(e.target.id)}
-          className={`${styles[dragon.reserved ? '' : 'hide']} ${styles.cancelBtn}`}
-        >
-          Cancel Reservation
-        </button>
+        <div>
+          {dragon.reserved
+            ? (
+              <button
+                type="button"
+                id={dragon.id}
+                onClick={(e) => cancelClick(e.target.id)}
+                className={styles.cancelBtn}
+              >
+                Cancel Reservation
+              </button>
+            )
+            : (
+              <button
+                type="button"
+                id={dragon.id}
+                onClick={(e) => reserveClick(e.target.id)}
+                className={styles.reserveBtn}
+              >
+                Reserve Dragon
+              </button>
+            )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/DragonItem.js
+++ b/src/components/DragonItem.js
@@ -25,8 +25,11 @@ const DragonItem = (props) => {
       <div className={styles.dragonInfo}>
         <h2>{dragon.name}</h2>
         <p className={styles.dragonType}>
-          Type:
-          {dragon.type}
+          {dragon.reserved ? (<span className={styles.badge}>Reserved</span>) : ''}
+          <span>
+            Type:
+            {dragon.type}
+          </span>
         </p>
         <div>
           {dragon.reserved

--- a/src/components/styles/DragonItem.module.css
+++ b/src/components/styles/DragonItem.module.css
@@ -21,6 +21,17 @@
   padding: 0 2vw;
 }
 
+.badge {
+  border: none;
+  border-radius: 3px;
+  padding: 0.3em 0.5em;
+  margin-right: 1em;
+  background-color: #18a2b8;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: bold;
+}
+
 .dragonType {
   padding: 2vh 0;
 }
@@ -40,10 +51,6 @@
   cursor: pointer;
 }
 
-.reserveBtn.hide {
-  display: none;
-}
-
 .cancelBtn {
   border: 1px solid grey;
   border-radius: 4px;
@@ -57,8 +64,4 @@
   text-align: center;
   color: grey;
   cursor: pointer;
-}
-
-.cancelBtn.hide {
-  display: none;
 }

--- a/src/redux/dragons/dragons.js
+++ b/src/redux/dragons/dragons.js
@@ -1,5 +1,6 @@
 const GET_DRAGONS = 'get_dragons';
 const RESERVE_DRAGON = 'reserve_dragon';
+const CANCEL_DRAGON = 'cancel_dragon';
 const url = 'https://api.spacexdata.com/v3/dragons';
 const initialState = [];
 
@@ -14,6 +15,14 @@ const dragonReducer = (state = initialState, action) => {
           return dragon;
         }
         return { ...dragon, reserved: true };
+      });
+    }
+    case CANCEL_DRAGON: {
+      return state.map((dragon) => {
+        if (dragon.id !== action.payload) {
+          return dragon;
+        }
+        return { ...dragon, reserved: false };
       });
     }
     default:
@@ -52,5 +61,12 @@ const reserveDragon = (id) => (
   }
 );
 
-export { getDragons, reserveDragon };
+const cancelDragon = (id) => (
+  {
+    type: CANCEL_DRAGON,
+    payload: id,
+  }
+);
+
+export { getDragons, reserveDragon, cancelDragon };
 export default dragonReducer;


### PR DESCRIPTION
## Requirements
- Follow the same logic as with the "Reserve dragon" - but you need to set the `reserved` key to `false`. 
- Dispatch these actions upon click on the corresponding buttons.
- Dragons that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve dragon" (as per design).